### PR TITLE
Fix Log Warning on Shutdown

### DIFF
--- a/happybase/api.py
+++ b/happybase/api.py
@@ -153,7 +153,11 @@ class Connection(object):
 
         This method closes the underlying Thrift transport (TCP connection).
         """
-        logger.debug("Closing Thrift transport to %s:%d", self.host, self.port)
+        if logger:
+            # since close() is called during __del__, sometimes logger doesn't
+            # exist anymore
+            logger.debug("Closing Thrift transport to %s:%d", self.host,
+                         self.port)
         self.transport.close()
 
     def __del__(self):


### PR DESCRIPTION
Upon shutdown, this error was displayed:
Exception AttributeError: "'NoneType' object has no attribute 'debug'" in <bound method Connection.__del__ of <happybase.api.Connection object at 0x106878250>> ignored
