### PR TITLE
Multiple Thrift servers

### DIFF
--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -6,6 +6,8 @@ HappyBase connection module.
 
 import logging
 
+import random
+
 from thrift.transport.TSocket import TSocket
 from thrift.transport.TTransport import TBufferedTransport, TFramedTransport
 from thrift.protocol import TBinaryProtocol
@@ -107,6 +109,9 @@ class Connection(object):
 
         # Allow host and port to be None, which may be easier for
         # applications wrapping a Connection instance.
+        hosts = host.split(',') if host else []
+        if len(hosts)>1:
+            (host, _ , port)= random.choice(hosts).partition(':')
         self.host = host or DEFAULT_HOST
         self.port = port or DEFAULT_PORT
         self.timeout = timeout


### PR DESCRIPTION
I've encountered a problem that single Thrift server couldn't handle all connections, so I've started more instances of it. But there is only host can be provided as server in happybase API (as far as I understand). So, this is my suggestion.

Usage example:

```
import happybase

connection = happybase.Connection('localhost:9090,some.other.host:9091,another.host,192.168.1.2:9292')
connection = happybase.Connection('192.168.1.3')
connection = happybase.Connection('192.168.1.3', 9092)
connection = happybase.Connection('192.168.1.3:9090', 9092) #error
connection = happybase.Connection('localhost:9090,another.host,192.168.1.2:9292', 9834) # second param is ignored
```

Comma-separated hosts can now be provided as ThriftServer host. Random server is chosen and further all interactions use it. Port can be specified after semicolon. 
