### PR TITLE
Add support for TCompactProtocol

### DIFF
--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -81,6 +81,8 @@ class Connection(object):
     process as well. TBinaryAccelerated is the default protocol that
     happybase uses.
 
+    .. versionadded:: 0.9b
+       `protocol` argument
     .. versionadded:: 0.5
        `timeout` argument
 


### PR DESCRIPTION
The difference between TBinaryAccelerated and TCompact (from Wikipedia):
TBinaryProtocol – A straightforward binary format, simple, but not optimized for space efficiency. Faster to process than the text protocol but more difficult to debug.
TCompactProtocol – More compact binary format; typically more efficient to process as well

Seems like this would be useful. It does, like framed transports, require configuration changes on the server end as well.
