### PR TITLE
Enable building universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,5 @@ cover-html-dir = coverage/
 source-dir = doc/
 build-dir = doc/build/
 
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from os.path import join, dirname
 from setuptools import find_packages, setup
 
 __version__ = None
-execfile('happybase/_version.py')
+exec(open('happybase/_version.py', 'r').read())
 
 
 def get_file_contents(filename):


### PR DESCRIPTION
Remove the use of execfile() in setup.py so it can run under python 3.

Set the flag in setup.cfg to allow universal wheels.