### PR TITLE
Implement context manager protocol for Connection

### DIFF
--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -144,6 +144,14 @@ class Connection(object):
 
         self._initialized = True
 
+    def __enter__(self):
+        """Context enter."""
+        return self
+
+    def __exit__(self, e_type, e_value, e_traceback):
+        """Context exit"""
+        self.close() 
+
     def _refresh_thrift_client(self):
         """Refresh the Thrift socket, transport, and client."""
         socket = TSocket(self.host, self.port)


### PR DESCRIPTION
Add `__enter__` and `__exit__` methods for Connection class.  
Then we can use happybase.Connection in a with statement block.
```Python
with happybase.Connection(host) as conn:
    #some code
```