### PR TITLE
Updating TODO to reflect Py3 support in Thrift.

### DIFF
--- a/TODO.rst
+++ b/TODO.rst
@@ -17,5 +17,8 @@ future, depending on time, demand, and technical possibilities.
   becomes mainstream, and expose more of the underlying features nicely in the
   HappyBase API.
 
-* Python 3 support. This would be trivial for HappyBase, but the underlying
-  Thrift library needs to be Python 3 compatible first.
+* Python 3 support. This would be trivial for HappyBase, now that the
+  underlying Thrift library is Python 3 compatible. `Track`_ this
+  issue online.
+
+.. _Track: https://github.com/wbolster/happybase/issues/40


### PR DESCRIPTION
@wbolster FWIW I may also be willing / able to assist on #40. I was very worried that Thrift would require updating, but saw your [comment][2] and then confirmed `thrift` at least installs for Python 3.

Interested because we are considering building a layer around `happybase` for Google's newly released [Cloud BigTable][1].

[1]: https://cloud.google.com/bigtable/docs/
[2]: https://github.com/wbolster/happybase/issues/40#issuecomment-69743493