### PR TITLE
Counter Batches and Reverse table scans

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -27,9 +27,9 @@ Release date: 2014-02-25
 
 * Add support for retrieving sorted columns, which is possible with the HBase
   0.96 Thrift API. This feature uses a new `sorted_columns` argument to
-  :py:meth:`Table.scan`. An ```OrderedDict`` implementation is required for this
+  :py:meth:`Table.scan`. An ``OrderedDict`` implementation is required for this
   feature; with Python 2.7 this is available from the standard library, but for
-  Python 2.6 a separate ```ordereddict``` pacakge has to be installed from PyPI.
+  Python 2.6 a separate ``ordereddict`` package has to be installed from PyPI.
   (`issue #39 <https://github.com/wbolster/happybase/issues/39>`_)
 
 * The `batch_size` argument to :py:meth:`Table.scan` is no longer propagated to

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,7 +7,7 @@ Version history
 HappyBase 0.9
 -------------
 
-Release date: *not yet released*
+Release date: 2014-11-24
 
 * Fix an issue where scanners would return fewer results than expected due to
   HBase not always behaving as its documentation suggests (`issue #72

--- a/happybase/_version.py
+++ b/happybase/_version.py
@@ -5,4 +5,4 @@ This module defines the package version for use in __init__.py and
 setup.py.
 """
 
-__version__ = '0.9b'
+__version__ = '0.9'

--- a/happybase/_version.py
+++ b/happybase/_version.py
@@ -5,4 +5,4 @@ This module defines the package version for use in __init__.py and
 setup.py.
 """
 
-__version__ = '0.9-takealot'
+__version__ = '0.9'

--- a/happybase/table.py
+++ b/happybase/table.py
@@ -383,11 +383,8 @@ class Table(object):
                 else:
                     how_many = min(batch_size, limit - n_returned)
 
-                if how_many == 1:
-                    items = self.connection.client.scannerGet(scan_id)
-                else:
-                    items = self.connection.client.scannerGetList(
-                        scan_id, how_many)
+                items = self.connection.client.scannerGetList(
+                    scan_id, how_many)
 
                 if not items:
                     break  # scan has finished

--- a/happybase/table.py
+++ b/happybase/table.py
@@ -387,7 +387,7 @@ class Table(object):
                     scan_id, how_many)
 
                 if not items:
-                    break  # scan has finished
+                    return  # scan has finished
 
                 n_fetched += len(items)
 
@@ -401,7 +401,7 @@ class Table(object):
                     yield item.row, row
 
                     if limit is not None and n_returned == limit:
-                        break  # not interested in the remainder
+                        return  # scan has finished
         finally:
             self.connection.client.scannerClose(scan_id)
             logger.debug(


### PR DESCRIPTION
* Ability to batch counter increments and decrements.  This functions in exactly the same form as table.batch(), except one now calls:
```py
cb = table.counter_batch()
cb.counter_inc('row-key', 'cf1:counter1')
cb.counter_inc('row-key', 'cf1:counter2')
cb.send()
```
Or alternatively, one can use a context manager:
```py
with table.counter_batch(batch_size=1000) as cb:
    cb.counter_inc('row-key', 'cf1:counter1')
    cb.counter_inc('row-key', 'cf1:counter2')
```
* Added reverse table scans:
```py
for key, data in table.scan(reverse=True):
    print key, data
```
which will return the data in reversed order