### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ HappyBase
 **HappyBase** is a developer-friendly Python_ library to interact with Apache
 HBase_.
 
-* `Documentation <http://happybase.readthedocs.org/>`_ (Read the Docs)
+* `Documentation <https://happybase.readthedocs.io/>`_ (Read the Docs)
 * `Downloads <http://pypi.python.org/pypi/happybase/>`_ (PyPI)
 * `Source code <https://github.com/wbolster/happybase>`_ (Github)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,7 +81,7 @@ Additional documentation
 External links
 ==============
 
-* `Online documentation <http://happybase.readthedocs.org/>`_ (Read the Docs)
+* `Online documentation <https://happybase.readthedocs.io/>`_ (Read the Docs)
 * `Downloads <http://pypi.python.org/pypi/happybase/>`_ (PyPI)
 * `Source code <https://github.com/wbolster/happybase>`_ (Github)
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.