### PR TITLE
Explicitly close the opened connection

### DIFF
--- a/happybase/pool.py
+++ b/happybase/pool.py
@@ -75,7 +75,9 @@ class ConnectionPool(object):
         # The first connection is made immediately so that trivial
         # mistakes like unresolvable host names are raised immediately.
         # Subsequent connections are connected lazily.
-        with self.connection():
+        with self.connection() as conn:
+            # Close the connection explicitly. Otherwise spawning processes may inherit the open fd.
+            conn.close()
             pass
 
     def _acquire_connection(self, timeout=None):


### PR DESCRIPTION
If a connection pool is created in a multiprocess environment, e.g. in settings.py of a Django app hosted by uWSGI with multiple workers, spawning processes will inherit the open fd and may close a connection that the parent process is still using.

Unfortunately, I was unable to create a simple test case to trigger this.
