### PR TITLE
Set socket timeout unconditionally on TSocket

### DIFF
--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -151,9 +151,7 @@ class Connection(object):
 
     def _refresh_thrift_client(self):
         """Refresh the Thrift socket, transport, and client."""
-        socket = TSocket(self.host, self.port)
-        if self.timeout is not None:
-            socket.set_timeout(self.timeout)
+        socket = TSocket(host=self.host, port=self.port, socket_timeout=self.timeout)
 
         self.transport = self._transport_class(socket)
         protocol = self._protocol_class(self.transport, decode_response=False)


### PR DESCRIPTION
Since thriftpy 0.3.3, there has been a `socket_timeout` option to `TSocket`. The default is 3000 ms. Setting it to `None` means "never timeout". Remove the `if self.timeout is not None` conditional so a value of `None` can also be set explicitly from happybase.