### PR TITLE
add ConnectionPool.autoconnect

### DIFF
--- a/happybase/pool.py
+++ b/happybase/pool.py
@@ -48,10 +48,14 @@ class ConnectionPool(object):
     task of the pool.
 
     :param int size: the maximum number of concurrently open connections
+    :param bool autoconnect: Whether a connection should be created upon
+        instantiation to test connection availability.
+        Note: the `autoconnect` flag of Connection instance inside the pool
+        is always False.
     :param kwargs: keyword arguments passed to
                    :py:class:`happybase.Connection`
     """
-    def __init__(self, size, **kwargs):
+    def __init__(self, size, autoconnect=True, **kwargs):
         if not isinstance(size, int):
             raise TypeError("Pool 'size' arg must be an integer")
 
@@ -72,11 +76,12 @@ class ConnectionPool(object):
             connection = Connection(**connection_kwargs)
             self._queue.put(connection)
 
-        # The first connection is made immediately so that trivial
-        # mistakes like unresolvable host names are raised immediately.
-        # Subsequent connections are connected lazily.
-        with self.connection():
-            pass
+        if autoconnect:
+            # The first connection is made immediately so that trivial
+            # mistakes like unresolvable host names are raised immediately.
+            # Subsequent connections are connected lazily.
+            with self.connection():
+                pass
 
     def _acquire_connection(self, timeout=None):
         """Acquire a connection from the pool."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ from nose.tools import (
     assert_false,
     assert_in,
     assert_is_instance,
+    assert_is_none,
     assert_is_not_none,
     assert_list_equal,
     assert_not_in,
@@ -486,6 +487,9 @@ def test_connection_pool_construction():
 
     with assert_raises(ValueError):
         ConnectionPool(size=0)
+
+    pool = ConnectionPool(size=1, autoconnect=False)
+    assert_is_none(getattr(pool._thread_connections, 'current'))
 
 
 def test_connection_pool():


### PR DESCRIPTION
According to discussion in #143, this PR add a `autoconnect` argument to ConnectionPool constructor.