### PR TITLE
Update __init__.py

### DIFF
--- a/happybase/__init__.py
+++ b/happybase/__init__.py
@@ -5,7 +5,14 @@ HBase.
 
 import pkg_resources as _pkg_resources
 import thriftpy as _thriftpy
-_thriftpy.load(
+import platform
+
+if platform.system()=="Windows":
+   _thriftpy.load(
+    'file://'+_pkg_resources.resource_filename('happybase', 'Hbase.thrift'),
+    'Hbase_thrift')
+else:
+   _thriftpy.load(
     _pkg_resources.resource_filename('happybase', 'Hbase.thrift'),
     'Hbase_thrift')
 


### PR DESCRIPTION
On non-Windows systems: things stay as they are
On windows system: it would pass the path to the thrift file with "file://" scheme.
If ThriftPY is fixed to handle the 'file' scheme - things would work on windows.
Until then, things will stay broken, as they are now.

This is further discussed here: https://github.com/wbolster/happybase/issues/148
and here:  https://github.com/eleme/thriftpy/issues/269

NOTE: I created a corresponding fork and pull request on thrifypy as well:
 https://github.com/eleme/thriftpy/pull/270