### PR TITLE
Adding reversed scanner, and new compat mode 0.98

### DIFF
--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 STRING_OR_BINARY = (six.binary_type, six.text_type)
 
-COMPAT_MODES = ('0.90', '0.92', '0.94', '0.96')
+COMPAT_MODES = ('0.90', '0.92', '0.94', '0.96', '0.98')
 THRIFT_TRANSPORTS = dict(
     buffered=TBufferedTransport,
     framed=TFramedTransport,
@@ -33,7 +33,7 @@ THRIFT_PROTOCOLS = dict(
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 9090
 DEFAULT_TRANSPORT = 'buffered'
-DEFAULT_COMPAT = '0.96'
+DEFAULT_COMPAT = '0.98'
 DEFAULT_PROTOCOL = 'binary'
 
 

--- a/happybase/table.py
+++ b/happybase/table.py
@@ -222,7 +222,7 @@ class Table(object):
     def scan(self, row_start=None, row_stop=None, row_prefix=None,
              columns=None, filter=None, timestamp=None,
              include_timestamp=False, batch_size=1000, scan_batching=None,
-             limit=None, sorted_columns=False):
+             limit=None, sorted_columns=False, reversed=False):
         """Create a scanner for data in the table.
 
         This method returns an iterable that can be used for looping over the
@@ -267,6 +267,11 @@ class Table(object):
         If `sorted_columns` is `True`, the columns in the rows returned
         by this scanner will be retrieved in sorted order, and the data
         will be stored in `OrderedDict` instances.
+        
+        If `reversed` is `True`, the scanner will perform the scan in reverse.
+        This means that `row_start` must be lexicographically after `row_stop`.
+        Note that the start of the range is inclusive, while the end is
+        exclusive just as in the forward scan.
 
         **Compatibility notes:**
 
@@ -276,6 +281,9 @@ class Table(object):
 
         * The `sorted_columns` argument is only available when using
           HBase 0.96 (or up).
+
+        * The `reversed` argument is only available when using HBase 0.98
+          (or up)
 
         .. versionadded:: 0.8
            `sorted_columns` argument
@@ -294,6 +302,7 @@ class Table(object):
         :param bool scan_batching: server-side scan batching (optional)
         :param int limit: max number of rows to return
         :param bool sorted_columns: whether to return sorted columns
+        :param bool reversed: whether to perform scan in reverse
 
         :return: generator yielding the rows matching the scan
         :rtype: iterable of `(row_key, row_data)` tuples
@@ -311,14 +320,22 @@ class Table(object):
             raise NotImplementedError(
                 "'sorted_columns' is only supported in HBase >= 0.96")
 
+        if reversed and self.connection.compat < '0.98':
+            raise NotImplementedError(
+                "'reversed' is only supported in HBase >= 0.98")
+
         if row_prefix is not None:
             if row_start is not None or row_stop is not None:
                 raise TypeError(
                     "'row_prefix' cannot be combined with 'row_start' "
                     "or 'row_stop'")
 
-            row_start = row_prefix
-            row_stop = bytes_increment(row_prefix)
+            if reversed:
+                row_start = bytes_increment(row_prefix)
+                row_stop = row_prefix
+            else:
+                row_start = row_prefix
+                row_stop = bytes_increment(row_prefix)
 
         if row_start is None:
             row_start = ''
@@ -376,6 +393,7 @@ class Table(object):
                 filterString=filter,
                 batchSize=scan_batching,
                 sortColumns=sorted_columns,
+                reversed=reversed
             )
             scan_id = self.connection.client.scannerOpenWithScan(
                 self.name, scan, {})

--- a/happybase/table.py
+++ b/happybase/table.py
@@ -222,7 +222,7 @@ class Table(object):
     def scan(self, row_start=None, row_stop=None, row_prefix=None,
              columns=None, filter=None, timestamp=None,
              include_timestamp=False, batch_size=1000, scan_batching=None,
-             limit=None, sorted_columns=False, reversed=False):
+             limit=None, sorted_columns=False, reverse=False):
         """Create a scanner for data in the table.
 
         This method returns an iterable that can be used for looping over the
@@ -267,8 +267,8 @@ class Table(object):
         If `sorted_columns` is `True`, the columns in the rows returned
         by this scanner will be retrieved in sorted order, and the data
         will be stored in `OrderedDict` instances.
-        
-        If `reversed` is `True`, the scanner will perform the scan in reverse.
+
+        If `reverse` is `True`, the scanner will perform the scan in reverse.
         This means that `row_start` must be lexicographically after `row_stop`.
         Note that the start of the range is inclusive, while the end is
         exclusive just as in the forward scan.
@@ -282,8 +282,11 @@ class Table(object):
         * The `sorted_columns` argument is only available when using
           HBase 0.96 (or up).
 
-        * The `reversed` argument is only available when using HBase 0.98
-          (or up)
+        * The `reverse` argument is only available when using HBase 0.98
+          (or up).
+
+        .. versionadded:: TODO
+           `reverse` argument
 
         .. versionadded:: 0.8
            `sorted_columns` argument
@@ -302,7 +305,7 @@ class Table(object):
         :param bool scan_batching: server-side scan batching (optional)
         :param int limit: max number of rows to return
         :param bool sorted_columns: whether to return sorted columns
-        :param bool reversed: whether to perform scan in reverse
+        :param bool reverse: whether to perform scan in reverse
 
         :return: generator yielding the rows matching the scan
         :rtype: iterable of `(row_key, row_data)` tuples
@@ -320,9 +323,9 @@ class Table(object):
             raise NotImplementedError(
                 "'sorted_columns' is only supported in HBase >= 0.96")
 
-        if reversed and self.connection.compat < '0.98':
+        if reverse and self.connection.compat < '0.98':
             raise NotImplementedError(
-                "'reversed' is only supported in HBase >= 0.98")
+                "'reverse' is only supported in HBase >= 0.98")
 
         if row_prefix is not None:
             if row_start is not None or row_stop is not None:
@@ -330,7 +333,7 @@ class Table(object):
                     "'row_prefix' cannot be combined with 'row_start' "
                     "or 'row_stop'")
 
-            if reversed:
+            if reverse:
                 row_start = bytes_increment(row_prefix)
                 row_stop = row_prefix
             else:
@@ -393,7 +396,7 @@ class Table(object):
                 filterString=filter,
                 batchSize=scan_batching,
                 sortColumns=sorted_columns,
-                reversed=reversed
+                reversed=reverse,
             )
             scan_id = self.connection.client.scannerOpenWithScan(
                 self.name, scan, {})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,7 +27,7 @@ from happybase import Connection, ConnectionPool, NoConnectionsAvailable
 
 HAPPYBASE_HOST = os.environ.get('HAPPYBASE_HOST')
 HAPPYBASE_PORT = os.environ.get('HAPPYBASE_PORT')
-HAPPYBASE_COMPAT = os.environ.get('HAPPYBASE_COMPAT', '0.96')
+HAPPYBASE_COMPAT = os.environ.get('HAPPYBASE_COMPAT', '0.98')
 HAPPYBASE_TRANSPORT = os.environ.get('HAPPYBASE_TRANSPORT', 'buffered')
 KEEP_TABLE = ('HAPPYBASE_NO_CLEANUP' in os.environ)
 
@@ -444,6 +444,31 @@ def test_scan_sorting():
     assert_list_equal(
         sorted(input_row.items()),
         list(row.items()))
+
+
+def test_scan_reversed():
+    if connection.compat < '0.98':
+        return  # not supported
+
+    with table.batch() as b:
+        for i in range(2000):
+            b.put(('row-scan-reversed-%04d' % i).encode('ascii'),
+                  {b'cf1:col1': b'v1',
+                   b'cf1:col2': b'v2'})
+
+    scan = table.scan(row_prefix=b'row-scan-reversed', reversed=True)
+    assert_equal(2000, len(list(scan)))
+
+    scan = table.scan(reversed=True, limit=10)
+    assert_equal(10, len(list(scan)))
+
+    scan = table.scan(row_start=b'row-scan-reversed-1999',
+                      row_stop=b'row-scan-reversed-0000', reversed=True)
+    key, data = next(scan)
+    assert_equal(b'row-scan-reversed-1999', key)
+
+    key, data = list(scan)[-1]
+    assert_equal(b'row-scan-reversed-0001', key)
 
 
 def test_scan_filter_and_batch_size():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -446,29 +446,32 @@ def test_scan_sorting():
         list(row.items()))
 
 
-def test_scan_reversed():
+def test_scan_reverse():
+
     if connection.compat < '0.98':
-        return  # not supported
+        with assert_raises(NotImplementedError):
+            list(table.scan(reverse=True))
+        return
 
     with table.batch() as b:
         for i in range(2000):
-            b.put(('row-scan-reversed-%04d' % i).encode('ascii'),
+            b.put(('row-scan-reverse-%04d' % i).encode('ascii'),
                   {b'cf1:col1': b'v1',
                    b'cf1:col2': b'v2'})
 
-    scan = table.scan(row_prefix=b'row-scan-reversed', reversed=True)
+    scan = table.scan(row_prefix=b'row-scan-reverse', reverse=True)
     assert_equal(2000, len(list(scan)))
 
-    scan = table.scan(reversed=True, limit=10)
+    scan = table.scan(limit=10, reverse=True)
     assert_equal(10, len(list(scan)))
 
-    scan = table.scan(row_start=b'row-scan-reversed-1999',
-                      row_stop=b'row-scan-reversed-0000', reversed=True)
+    scan = table.scan(row_start=b'row-scan-reverse-1999',
+                      row_stop=b'row-scan-reverse-0000', reverse=True)
     key, data = next(scan)
-    assert_equal(b'row-scan-reversed-1999', key)
+    assert_equal(b'row-scan-reverse-1999', key)
 
     key, data = list(scan)[-1]
-    assert_equal(b'row-scan-reversed-0001', key)
+    assert_equal(b'row-scan-reverse-0001', key)
 
 
 def test_scan_filter_and_batch_size():


### PR DESCRIPTION
#67 implementing the reversed scan found in [HBase 0.98](https://issues.apache.org/jira/browse/HBASE-4811). 

I did not add a `.. versionadded:` to the docs, waiting to see if the PR will be accepted, and which version number to add.