### PR TITLE
update to thriftpy2

### DIFF
--- a/happybase/__init__.py
+++ b/happybase/__init__.py
@@ -4,7 +4,7 @@ HBase.
 """
 
 import pkg_resources as _pkg_resources
-import thriftpy as _thriftpy
+import thriftpy2 as _thriftpy
 _thriftpy.load(
     _pkg_resources.resource_filename('happybase', 'Hbase.thrift'),
     'Hbase_thrift')

--- a/happybase/connection.py
+++ b/happybase/connection.py
@@ -7,9 +7,9 @@ HappyBase connection module.
 import logging
 
 import six
-from thriftpy.thrift import TClient
-from thriftpy.transport import TBufferedTransport, TFramedTransport, TSocket
-from thriftpy.protocol import TBinaryProtocol, TCompactProtocol
+from thriftpy2.thrift import TClient
+from thriftpy2.transport import TBufferedTransport, TFramedTransport, TSocket
+from thriftpy2.protocol import TBinaryProtocol, TCompactProtocol
 
 from Hbase_thrift import Hbase, ColumnDescriptor
 

--- a/happybase/pool.py
+++ b/happybase/pool.py
@@ -9,7 +9,7 @@ import threading
 
 from six.moves import queue, range
 
-from thriftpy.thrift import TException
+from thriftpy2.thrift import TException
 
 from .connection import Connection
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six
-thriftpy>=0.3.8
+thriftpy2>=0.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -518,7 +518,7 @@ def test_connection_pool_construction():
 
 def test_connection_pool():
 
-    from thriftpy.thrift import TException
+    from thriftpy2.thrift import TException
 
     def run():
         name = threading.current_thread().name


### PR DESCRIPTION
thriftpy is unsupported and doesn't build on 3.7.

closes #221.